### PR TITLE
Add WebGL VHS/NTSC signal filter

### DIFF
--- a/docs/plan/038-vhs-ntsc-webgl.md
+++ b/docs/plan/038-vhs-ntsc-webgl.md
@@ -1,0 +1,100 @@
+# 038 - VHS/NTSC WebGL Signal Model
+
+## Goal
+
+Improve the existing stylized VHS effect and add a separate WebGL2-only
+VHS/NTSC filter derived from the signal-processing structure used by
+`ntsc-rs`.
+
+The new filter ports the browser-relevant image pipeline, not the upstream
+desktop application, codecs, CLI, or editor plugins.
+
+## Existing VHS Changes
+
+- Make row tracking evolve smoothly between frames instead of reseeding into
+  unrelated geometry every frame.
+- Generate dropout streak and static-bar geometry once on the CPU and pass the
+  exact state to WebGL so the CPU and GL paths agree.
+- Make fractional dropout/static rates work at their defaults.
+- Process luma and chroma in YIQ in the shader, including horizontal chroma
+  bandwidth loss, vertical chroma blending, chroma phase noise, asymmetric
+  luma smear, and a short same-frame RF echo.
+- Apply temporal ghosting after dropout/static synthesis in both backends.
+- Apply the palette after temporal blending in both backends.
+- Raise the default chroma-bandwidth loss so the default preset reads as tape
+  rather than a generic RGB glitch.
+
+## New VHS/NTSC Filter
+
+Add a GL-only, animated filter with three passes:
+
+1. **Composite encode/transmit**
+   - Convert RGB to YIQ.
+   - Band-limit input chroma.
+   - Modulate I/Q onto a four-pixel NTSC carrier.
+   - Apply field selection, edge wave, head switching, tracking disturbance,
+     composite noise, and snow to the scalar composite signal.
+2. **Composite decode**
+   - Recover luma/chroma with selectable notch, one-line comb, or two-line
+     comb behavior.
+   - Reconstruct signed YIQ into an intermediate texture.
+3. **Tape/decode output**
+   - Apply SP/LP/EP luma and chroma bandwidth profiles and chroma delay.
+   - Apply vertical chroma blending, chroma loss, phase error/noise, luma
+     smear/ringing, and separate luma/chroma noise.
+   - Convert YIQ back to RGB.
+
+The filter exposes the important upstream concepts without reproducing all 62
+advanced settings. Settings are expressed in Ditherer's data-driven control
+system and the filter remains chain-composable.
+
+## Testing
+
+- Add pure tests for fractional event counts and smooth tracking state.
+- Assert the new filter metadata, GL requirement, defaults, and registry entry.
+- Use the existing registry tests to protect worker lookup/deserialization.
+- Compile the shaders in the existing WebGL2 browser smoke test.
+
+## Verification
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test -- test/filters/vhsNtsc.test.ts test/filters/filterRegistry.test.ts`
+- `npm run test`
+- `npm run build`
+- `npm run test:e2e:gl`
+
+## Upstream Validation and Known Delta
+
+Validated against `ntsc-rs` commit
+`f76c218c51e6fa7218dcb72f6f19a72d81bcd778`:
+
+- The upstream core passes all 66 library tests.
+- Default LP tape settings agree on the important signal parameters: 1.9 MHz
+  luma cutoff, 300 kHz chroma cutoff, five-sample chroma delay, Butterworth
+  filtering, notch demodulation, interleaved fields, 180-degree scanline
+  phase, vertical chroma blend, and the default noise/loss probabilities.
+- A 640x480 reference render of the upstream benchmark image was compared to
+  this WebGL filter at frame zero. The final browser candidate measured RGB
+  MAE 21.86, luma MAE 10.34, and PSNR 17.85 dB against the upstream output.
+  Relative to the source, WebGL changed luma by 4.99 levels and chroma by
+  8.91 YIQ units; upstream changed them by 12.78 and 20.09 respectively.
+- The comparison ran on ANGLE's Vulkan SwiftShader renderer and took 149 ms.
+  This is a correctness reference, not a hardware-GPU performance result.
+
+The remaining delta is intentional and documented:
+
+- `ntsc-rs` uses recursive constant-K/Butterworth transfer functions. WebGL
+  fragment shaders cannot carry scanline recursion between fragments, so the
+  port uses bounded gather kernels (up to 17 taps). This makes the default
+  result milder and avoids the upstream filter's left-edge initialization
+  stripe.
+- Composite and YIQ intermediates use portable RGBA8 render targets, adding
+  quantization that the upstream float planes do not have.
+- Field phase and comb stride are reproduced, but the shader does not split
+  the image into two separately processed field buffers as upstream does.
+  Both field parities therefore share disturbance state within a frame.
+- Noise uses deterministic shader hashes/sine FBM rather than upstream
+  SplitMix64/simplex noise, so defect locations are not pixel-identical.
+- The browser filter exposes the signal/tape controls relevant to this app,
+  not every desktop/plugin setting or the upstream codec/editor integrations.

--- a/gl-smoke.html
+++ b/gl-smoke.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GL Smoke</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <main>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:4173",
     headless: true,
+    launchOptions: {
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+      args: process.env.PLAYWRIGHT_ANGLE === "1"
+        ? ["--use-gl=angle", "--use-angle=gl"]
+        : undefined,
+    },
   },
   webServer: {
     command: "env -u NO_COLOR -u FORCE_COLOR npm run dev -- --host 127.0.0.1 --port 4173",

--- a/src/filters/cameraShake.ts
+++ b/src/filters/cameraShake.ts
@@ -209,8 +209,8 @@ void main() {
   vec2 p = v_uv * u_resolution;
   vec2 d = (p - u_centerPx) * u_invZoom;
   // [c -s; s c] * d  matches the JS: srcX = cx + dx*c - dy*s + offX
-  vec2 sample = u_centerPx + vec2(d.x * u_cosA - d.y * u_sinA, d.x * u_sinA + d.y * u_cosA) + u_offsetPx;
-  vec2 snapped = clamp(floor(sample + 0.5) + 0.5, vec2(0.5), u_resolution - vec2(0.5));
+  vec2 samplePx = u_centerPx + vec2(d.x * u_cosA - d.y * u_sinA, d.x * u_sinA + d.y * u_cosA) + u_offsetPx;
+  vec2 snapped = clamp(floor(samplePx + 0.5) + 0.5, vec2(0.5), u_resolution - vec2(0.5));
   vec4 c = texture(u_source, snapped / u_resolution);
   vec3 q = c.rgb * 255.0;
   if (u_paletteLevels >= 2 && u_paletteLevels < 256) {

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -7,6 +7,7 @@ import binarize from "./binarize";
 import channelSeparation from "./channelSeparation";
 import jitter from "./jitter";
 import vhs from "./vhs";
+import vhsNtsc from "./vhsNtsc";
 import program from "./program";
 import brightnessContrast from "./brightnessContrast";
 import convolve, { LAPLACIAN_3X3 } from "./convolve";
@@ -271,6 +272,7 @@ export { default as noop } from "./noop";
 export { default as channelSeparation } from "./channelSeparation";
 export { default as jitter } from "./jitter";
 export { default as vhs } from "./vhs";
+export { default as vhsNtsc } from "./vhsNtsc";
 export { default as binarize } from "./binarize";
 export { default as program } from "./program";
 export { default as brightnessContrast } from "./brightnessContrast";
@@ -906,6 +908,7 @@ export const filterList = [
   { displayName: "Thermal printer", filter: thermalPrinter, category: "Simulate", description: "Receipt printer — low-res dots, paper curl gradient, thermal ink fade" },
   { displayName: "Ultrasound", filter: ultrasound, category: "Simulate", description: "Medical ultrasound display — fan-shaped sector scan with speckle noise" },
   { displayName: "VHS emulation", filter: vhs, category: "Simulate", description: "Simulate VHS tape — tracking errors, chroma delay, head-switching noise, and ghosting" },
+  { displayName: "VHS / NTSC", filter: vhsNtsc, category: "Simulate", description: "Signal-model VHS — YIQ composite modulation, NTSC decoding, tape-speed bandwidth, tracking, snow, and chroma loss" },
   { displayName: "Vintage TV", filter: vintageTV, category: "Simulate", description: "Old TV with banding, color fringe, vertical roll, and glow — animatable" },
   { displayName: "Motion Analysis", filter: motionDetect, category: "Simulate", description: "Analyze motion against the background model or previous frame and render it as a mask, highlight, or persistent heatmap" },
   { displayName: "Long Exposure", filter: longExposure, category: "Simulate", description: "Blend, average, or accumulate recent frames for ghost trails, slow-shutter smear, and long-exposure light painting" },

--- a/src/filters/vhs.ts
+++ b/src/filters/vhs.ts
@@ -5,8 +5,6 @@ import {
   cloneCanvas,
   fillBufferPixel,
   getBufferIndex,
-  rgba,
-  paletteGetColor,
   logFilterBackend,
 } from "utils";
 import { applyPalettePassToCanvas, paletteIsIdentity } from "palettes/backend";
@@ -28,10 +26,10 @@ export const optionTypes = {
   headSwitchingHeight: { type: RANGE, range: [0, 80], step: 1, default: 20, desc: "Height of the bottom-edge head switching band" },
   dropout: { type: RANGE, range: [0, 1], step: 0.01, default: 0.1, desc: "Probability of white signal-loss streaks per frame" },
   tapeNoise: { type: RANGE, range: [0, 1], step: 0.01, default: 0.15, desc: "Per-row brightness noise and static bar frequency" },
-  ghosting: { type: RANGE, range: [0, 1], step: 0.01, default: 0.3, desc: "Previous-frame bleed-through (temporal smear)" },
+  ghosting: { type: RANGE, range: [0, 1], step: 0.01, default: 0.3, desc: "Short RF echo plus previous-frame bleed-through" },
   brightness: { type: RANGE, range: [-100, 100], step: 1, default: -15, desc: "Overall brightness offset applied after VHS processing" },
   saturation: { type: RANGE, range: [0, 2], step: 0.05, default: 1.1, desc: "Chroma saturation multiplier" },
-  chromaBandwidth: { type: RANGE, range: [0, 16], step: 1, default: 0, desc: "Horizontal chroma low-pass radius — VHS smeared colour relative to luma (0 = off; raise for stronger tape look)" },
+  chromaBandwidth: { type: RANGE, range: [0, 16], step: 1, default: 4, desc: "Horizontal chroma low-pass radius — VHS smeared colour relative to luma (0 = off; raise for stronger tape look)" },
   animSpeed: { type: RANGE, range: [1, 30], step: 1, default: 12 },
   animate: {
     type: ACTION,
@@ -44,7 +42,7 @@ export const optionTypes = {
       }
     }
   },
-  blur: { type: BOOL, default: true, desc: "Apply soft Gaussian blur to simulate analog softness" },
+  blur: { type: BOOL, default: true, desc: "Apply asymmetric luma smear and extra chroma softness" },
   palette: { type: PALETTE, default: nearest }
 };
 
@@ -106,6 +104,37 @@ const mulberry32 = (seed: number) => {
   };
 };
 
+export const stochasticEventCount = (expected: number, roll: number): number => {
+  const base = Math.max(0, Math.floor(expected));
+  return base + (roll < expected - base ? 1 : 0);
+};
+
+export const buildTrackingRowShift = (
+  height: number,
+  tracking: number,
+  trackingSpread: number,
+  frameIndex: number,
+): Int32Array => {
+  const profileDuration = 8;
+  const phase = Math.max(0, frameIndex) / profileDuration;
+  const profileIndex = Math.floor(phase);
+  const rawBlend = phase - profileIndex;
+  const blend = rawBlend * rawBlend * (3 - 2 * rawBlend);
+  const rngA = mulberry32(profileIndex * 7919 + 31337);
+  const rngB = mulberry32((profileIndex + 1) * 7919 + 31337);
+  const rowShift = new Int32Array(height);
+  let driftA = 0;
+  let driftB = 0;
+
+  for (let y = 0; y < height; y++) {
+    driftA = (driftA + (rngA() - 0.5) * tracking * 2) * trackingSpread;
+    driftB = (driftB + (rngB() - 0.5) * tracking * 2) * trackingSpread;
+    rowShift[y] = Math.round(driftA * (1 - blend) + driftB * blend);
+  }
+
+  return rowShift;
+};
+
 const vhs = (
   input: any,
   options: VhsOptions = defaults
@@ -142,7 +171,7 @@ const vhs = (
   const buf = inputCtx.getImageData(0, 0, W, H).data;
   const outBuf = new Uint8ClampedArray(buf.length);
 
-  // Per-frame seeded random for consistent-looking noise within a frame
+  // Per-frame seeded random for consistent-looking noise within a frame.
   const rng = mulberry32(frameIndex * 7919 + 31337);
 
   // Vertical jitter — whole frame shifts up/down per frame
@@ -150,14 +179,9 @@ const vhs = (
     ? Math.round(Math.sin(frameIndex * 3.7 + Math.cos(frameIndex * 1.3)) * verticalJitter)
     : 0;
 
-  // Pre-compute horizontal tracking jitter per row (random walk)
-  const rowShift = new Int32Array(H);
-  let drift = 0;
-  for (let y = 0; y < H; y++) {
-    drift += (rng() - 0.5) * tracking * 2;
-    drift *= trackingSpread;
-    rowShift[y] = Math.round(drift);
-  }
+  // Pre-compute horizontal tracking jitter per row. Profiles crossfade over
+  // eight frames so tracking crawls instead of popping to unrelated geometry.
+  const rowShift = buildTrackingRowShift(H, tracking, trackingSpread, frameIndex);
 
   // Flagging — top rows bend/hook horizontally, worse at very top
   if (flagging > 0 && flaggingHeight > 0) {
@@ -181,7 +205,7 @@ const vhs = (
   const dropouts: Array<{ y: number; x: number; w: number }> = [];
   if (dropout > 0) {
     const dropRng = mulberry32(frameIndex * 4391 + 17);
-    const dropCount = Math.floor(dropRng() * 8 * dropout);
+    const dropCount = stochasticEventCount(8 * dropout, dropRng());
     for (let d = 0; d < dropCount; d++) {
       dropouts.push({
         y: Math.floor(dropRng() * H),
@@ -204,7 +228,7 @@ const vhs = (
   // Occasional horizontal noise bars (2-4px tall bands of static)
   const noiseBars: Array<{ y: number; h: number }> = [];
   if (tapeNoise > 0) {
-    const barCount = Math.floor(rng() * 4 * tapeNoise);
+    const barCount = stochasticEventCount(4 * tapeNoise, rng());
     for (let b = 0; b < barCount; b++) {
       noiseBars.push({
         y: Math.floor(rng() * H),
@@ -218,16 +242,23 @@ const vhs = (
   // shader does the final blend. Palette is applied post-readout.
   if (options._webglAcceleration !== false && vhsGLAvailable()) {
     const staticBar = new Uint8Array(H);
+    const dropoutPacked = new Float32Array(H);
     for (const bar of noiseBars) {
       for (let dy = 0; dy < bar.h; dy++) {
         const row = bar.y + dy;
         if (row >= 0 && row < H) staticBar[row] = 1;
       }
     }
+    for (const drop of dropouts) {
+      // One packed streak per scanline: integer = start + 1, fraction = width.
+      // Multiple generated streaks on one row coalesce to the latest one.
+      dropoutPacked[drop.y] = drop.x + 1 + drop.w / (W + 1);
+    }
     const rendered = renderVHSGL(input, W, H, {
       rowShift,
       rowNoise,
       staticBar,
+      dropoutPacked,
       vJitter,
       chromaOffX,
       chromaOffY,
@@ -235,7 +266,6 @@ const vhs = (
       saturation,
       brightness,
       ghosting,
-      dropoutProb: dropout,
       tapeNoise,
       frameIndex,
       prevOutput,
@@ -322,8 +352,7 @@ const vhs = (
       g = Math.max(0, Math.min(255, g));
       b = Math.max(0, Math.min(255, b));
 
-      const color = paletteGetColor(palette, rgba(r, g, b, buf[lumaI + 3]), palette.options, false);
-      fillBufferPixel(outBuf, i, color[0], color[1], color[2], buf[lumaI + 3]);
+      fillBufferPixel(outBuf, i, r, g, b, buf[lumaI + 3]);
     }
   }
 
@@ -352,7 +381,8 @@ const vhs = (
     }
   }
 
-  return output;
+  const identity = paletteIsIdentity(palette);
+  return identity ? output : (applyPalettePassToCanvas(output, W, H, palette) ?? output);
 };
 
 export default defineFilter({

--- a/src/filters/vhsGL.ts
+++ b/src/filters/vhsGL.ts
@@ -4,19 +4,16 @@ import {
   type Program,
 } from "gl";
 
-// Row-wise state (tracking/noise/dropouts) is pre-computed on CPU with
-// the same mulberry32 seeds as the JS reference and uploaded as an RG16F
-// texture: .r = horizontal shift in pixels, .g = brightness multiplier.
-// Dropouts and noise bars become an RGBA32F "overlay" texture: .r > 0
-// marks static bars (value = row-noise brightness so the bar is visible),
-// .g > 0 marks dropouts with their x-extent packed in .b/.a.
+// Row-wise state is pre-computed on CPU and uploaded as RGBA32F:
+// shift, brightness multiplier, static-bar flag, packed dropout geometry.
+// That keeps artifact placement consistent with the CPU fallback.
 const VHS_FS = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 out vec4 fragColor;
 
 uniform sampler2D u_source;
-uniform sampler2D u_rowState;   // per row: (shift, rowNoise, barBrightness, dropoutHash)
+uniform sampler2D u_rowState;   // per row: (shift, rowNoise, staticBar, packedDropout)
 uniform sampler2D u_prev;       // previous frame (optional, same-size)
 uniform vec2  u_res;
 uniform float u_vJitter;
@@ -27,17 +24,35 @@ uniform float u_saturation;
 uniform float u_brightness;     // -100..100
 uniform float u_ghosting;       // 0..1
 uniform int   u_hasPrev;        // 1 if prev provided
-uniform float u_dropoutProb;
 uniform float u_tapeNoise;
 uniform float u_frameIndex;     // per-frame hash seed
 
 float hash(vec2 p) { return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453); }
-float luma3(vec3 c) { return 0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b; }
+
+vec3 rgbToYiq(vec3 c) {
+  return vec3(
+    dot(c, vec3(0.299, 0.587, 0.114)),
+    dot(c, vec3(0.5959, -0.2746, -0.3213)),
+    dot(c, vec3(0.2115, -0.5227, 0.3112))
+  );
+}
+
+vec3 yiqToRgb(vec3 c) {
+  return vec3(
+    c.x + 0.956 * c.y + 0.619 * c.z,
+    c.x - 0.272 * c.y - 0.647 * c.z,
+    c.x - 1.106 * c.y + 1.703 * c.z
+  );
+}
 
 vec4 sampleJS(float sx, float sy) {
   float cx = clamp(sx, 0.0, u_res.x - 1.0);
   float cy = clamp(sy, 0.0, u_res.y - 1.0);
   return texture(u_source, vec2((cx + 0.5) / u_res.x, 1.0 - (cy + 0.5) / u_res.y));
+}
+
+vec3 sampleYiq(float sx, float sy) {
+  return rgbToYiq(sampleJS(sx, sy).rgb);
 }
 
 void main() {
@@ -49,95 +64,113 @@ void main() {
   float shift = rs.r;
   float rowNoise = rs.g;
   float barBri = rs.b;
+  float dropoutPacked = rs.a;
+  bool inDropout = false;
+  if (dropoutPacked > 0.0) {
+    float dropStart = floor(dropoutPacked) - 1.0;
+    float dropW = fract(dropoutPacked) * (u_res.x + 1.0);
+    inDropout = x >= dropStart && x < dropStart + dropW;
+  }
 
-  // Static bar: the whole row is random grey.
+  vec3 rgb;
+  float alpha = 1.0;
+
   if (barBri > 0.5) {
-    float n = hash(vec2(x, y + u_frameIndex));
-    fragColor = vec4(vec3(n), 1.0);
-    return;
-  }
-
-  // Dropout streaks — hashed start/length per row. A row either has one
-  // or none in GL (approximates the multi-streak CPU behaviour visibly).
-  if (u_dropoutProb > 0.0) {
-    float dh = hash(vec2(y + 3.0, u_frameIndex));
-    if (dh < clamp(u_dropoutProb, 0.0, 1.0)) {
-      float dropStart = hash(vec2(y + 11.0, u_frameIndex)) * u_res.x;
-      float dropW = 20.0 + hash(vec2(y + 23.0, u_frameIndex)) * u_res.x * 0.4;
-      if (x >= dropStart && x < dropStart + dropW) {
-        float n = 180.0 + hash(vec2(x + 7.0, y + u_frameIndex)) * 75.0;
-        fragColor = vec4(vec3(n / 255.0), 1.0);
-        return;
-      }
-    }
-  }
-
-  // Tape-noise bars — hashed per-row at low probability.
-  if (u_tapeNoise > 0.0 && hash(vec2(y + 97.0, u_frameIndex)) < u_tapeNoise * 0.02) {
-    float n = hash(vec2(x, y + u_frameIndex));
-    fragColor = vec4(vec3(n), 1.0);
-    return;
-  }
+    float n = hash(vec2(x, y + u_frameIndex * 19.0));
+    rgb = vec3(n);
+  } else if (inDropout) {
+    float n = (180.0 + hash(vec2(x + 7.0, y + u_frameIndex * 13.0)) * 75.0) / 255.0;
+    rgb = vec3(n);
+  } else {
 
   // Luma tap at the row's tracking-shifted position + frame vertical jitter.
   float srcY = clamp(y + u_vJitter, 0.0, u_res.y - 1.0);
   float lumaX = clamp(x + shift, 0.0, u_res.x - 1.0);
-  vec4 ls = sampleJS(lumaX, srcY);
-  float lumaV = luma3(ls.rgb) * 255.0;
+    vec4 ls = sampleJS(lumaX, srcY);
+    vec3 lumaTap = rgbToYiq(ls.rgb);
+    float lumaV = lumaTap.x;
+    alpha = ls.a;
 
   // Chroma tap at the delayed position, optionally low-pass filtered
   // horizontally to reproduce VHS 3.58 MHz chroma bandwidth (~250-line
   // colour vs ~330-line luma).
-  vec3 chromaSum = vec3(0.0);
-  float wsum = 0.0;
-  int band = int(clamp(u_chromaBandwidth, 0.0, 16.0));
-  for (int k = -16; k <= 16; k++) {
-    if (k < -band || k > band) continue;
-    float cx = clamp(x + shift + u_chromaOffX + float(k), 0.0, u_res.x - 1.0);
-    float cy = clamp(srcY + u_chromaOffY, 0.0, u_res.y - 1.0);
-    vec4 cs = sampleJS(cx, cy);
-    chromaSum += cs.rgb * 255.0;
-    wsum += 1.0;
-  }
-  vec3 chromaMean = chromaSum / wsum;
-  float chromaLuma = luma3(chromaMean / 255.0) * 255.0;
-  vec3 chroma = chromaMean - vec3(chromaLuma);
+    vec2 chromaSum = vec2(0.0);
+    float wsum = 0.0;
+    int band = int(clamp(u_chromaBandwidth, 0.0, 16.0));
+    for (int k = -16; k <= 16; k++) {
+      if (k < -band || k > band) continue;
+      float radius = max(float(band) + 1.0, 1.0);
+      float weight = 1.0 - abs(float(k)) / radius;
+      float cx = x + shift + u_chromaOffX + float(k);
+      float cy = srcY + u_chromaOffY;
+      vec3 centerYiq = sampleYiq(cx, cy);
+      vec3 aboveYiq = sampleYiq(cx, cy - 1.0);
+      chromaSum += mix(centerYiq.yz, aboveYiq.yz, 0.22) * weight;
+      wsum += weight;
+    }
+    vec2 chroma = chromaSum / max(wsum, 0.0001);
+
+    // Time-base error rotates the chroma vector by a small, scanline-specific
+    // amount. This produces tape-like hue flutter instead of RGB splitting.
+    float phaseNoise = (hash(vec2(y * 0.17, floor(u_frameIndex * 0.5))) - 0.5)
+      * u_tapeNoise * 0.42;
+    float cp = cos(phaseNoise);
+    float sp = sin(phaseNoise);
+    chroma = mat2(cp, sp, -sp, cp) * chroma;
+
+    // A short delayed luma echo approximates RF reflections/head crosstalk.
+    float echoOffset = 5.0 + floor(hash(vec2(y, 71.0)) * 5.0);
+    float echoY = sampleYiq(lumaX - echoOffset, srcY).x;
+    lumaV = mix(lumaV, lumaV * 0.88 + echoY * 0.12, u_ghosting);
 
   // Recombine: luma + chroma * saturation + brightness offset, then
   // multiply by per-row tape noise.
-  vec3 rgb = (vec3(lumaV) + chroma * u_saturation + vec3(u_brightness)) * rowNoise;
-  rgb = clamp(rgb, vec3(0.0), vec3(255.0)) / 255.0;
+    vec3 yiq = vec3(lumaV + u_brightness / 255.0, chroma * u_saturation);
+    rgb = clamp(yiqToRgb(yiq) * rowNoise, 0.0, 1.0);
+  }
 
   if (u_hasPrev == 1 && u_ghosting > 0.0) {
     vec3 prev = texture(u_prev, v_uv).rgb;
-    rgb = mix(rgb, prev, u_ghosting);
+    rgb = mix(rgb, prev, u_ghosting * 0.72);
   }
 
-  fragColor = vec4(rgb, ls.a);
+  fragColor = vec4(rgb, alpha);
 }
 `;
 
-// Optional 3x3 blur reproduces the "blur" checkbox's GAUSSIAN_3X3_WEAK.
+// Optional tape-softness pass. Luma trails asymmetrically while chroma also
+// blends vertically, closer to helical-scan playback than a generic Gaussian.
 const BLUR_FS = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 out vec4 fragColor;
 uniform sampler2D u_input;
 uniform vec2  u_res;
+vec3 rgbToYiq(vec3 c) {
+  return vec3(
+    dot(c, vec3(0.299, 0.587, 0.114)),
+    dot(c, vec3(0.5959, -0.2746, -0.3213)),
+    dot(c, vec3(0.2115, -0.5227, 0.3112))
+  );
+}
+vec3 yiqToRgb(vec3 c) {
+  return vec3(
+    c.x + 0.956 * c.y + 0.619 * c.z,
+    c.x - 0.272 * c.y - 0.647 * c.z,
+    c.x - 1.106 * c.y + 1.703 * c.z
+  );
+}
 void main() {
   vec2 texel = 1.0 / u_res;
-  // Matches convolve's GAUSSIAN_3X3_WEAK: [1 2 1; 2 4 2; 1 2 1] / 16.
-  vec4 acc = vec4(0.0);
-  acc += texture(u_input, v_uv + texel * vec2(-1.0, -1.0)) * 1.0;
-  acc += texture(u_input, v_uv + texel * vec2( 0.0, -1.0)) * 2.0;
-  acc += texture(u_input, v_uv + texel * vec2( 1.0, -1.0)) * 1.0;
-  acc += texture(u_input, v_uv + texel * vec2(-1.0,  0.0)) * 2.0;
-  acc += texture(u_input, v_uv + texel * vec2( 0.0,  0.0)) * 4.0;
-  acc += texture(u_input, v_uv + texel * vec2( 1.0,  0.0)) * 2.0;
-  acc += texture(u_input, v_uv + texel * vec2(-1.0,  1.0)) * 1.0;
-  acc += texture(u_input, v_uv + texel * vec2( 0.0,  1.0)) * 2.0;
-  acc += texture(u_input, v_uv + texel * vec2( 1.0,  1.0)) * 1.0;
-  fragColor = acc / 16.0;
+  vec4 c = texture(u_input, v_uv);
+  vec3 yc = rgbToYiq(c.rgb);
+  vec3 yl1 = rgbToYiq(texture(u_input, v_uv - texel * vec2(1.0, 0.0)).rgb);
+  vec3 yl2 = rgbToYiq(texture(u_input, v_uv - texel * vec2(2.0, 0.0)).rgb);
+  vec3 yr1 = rgbToYiq(texture(u_input, v_uv + texel * vec2(1.0, 0.0)).rgb);
+  vec3 ya = rgbToYiq(texture(u_input, v_uv + texel * vec2(0.0, 1.0)).rgb);
+  float y = yc.x * 0.55 + yl1.x * 0.25 + yl2.x * 0.12 + yr1.x * 0.08;
+  vec2 iq = yc.yz * 0.40 + yl1.yz * 0.22 + yr1.yz * 0.18 + ya.yz * 0.20;
+  fragColor = vec4(clamp(yiqToRgb(vec3(y, iq)), 0.0, 1.0), c.a);
 }
 `;
 
@@ -150,7 +183,7 @@ const initCache = (gl: WebGL2RenderingContext): Cache => {
       "u_source", "u_rowState", "u_prev", "u_res",
       "u_vJitter", "u_chromaOffX", "u_chromaOffY",
       "u_chromaBandwidth", "u_saturation", "u_brightness",
-      "u_ghosting", "u_hasPrev", "u_dropoutProb", "u_tapeNoise", "u_frameIndex",
+      "u_ghosting", "u_hasPrev", "u_tapeNoise", "u_frameIndex",
     ] as const),
     blur: linkProgram(gl, BLUR_FS, ["u_input", "u_res"] as const),
   };
@@ -158,12 +191,13 @@ const initCache = (gl: WebGL2RenderingContext): Cache => {
 };
 
 // Row-state texture: one row per scanline, RGBA channels = (shift,
-// rowNoise, isStaticBar, _unused).
+// rowNoise, isStaticBar, packed dropout geometry).
 const uploadRowState = (
   gl: WebGL2RenderingContext,
   rowShift: Int32Array,
   rowNoise: Float32Array,
   staticBar: Uint8Array,
+  dropoutPacked: Float32Array,
   height: number,
 ) => {
   const data = new Float32Array(height * 4);
@@ -171,7 +205,7 @@ const uploadRowState = (
     data[y * 4] = rowShift[y];
     data[y * 4 + 1] = rowNoise[y];
     data[y * 4 + 2] = staticBar[y];
-    data[y * 4 + 3] = 0;
+    data[y * 4 + 3] = dropoutPacked[y];
   }
   const tex = gl.createTexture();
   gl.activeTexture(gl.TEXTURE1);
@@ -200,7 +234,8 @@ const uploadPrevOutputTexture = (
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
   gl.texImage2D(
     gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0,
-    gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(prevOutput.buffer),
+    gl.RGBA, gl.UNSIGNED_BYTE,
+    new Uint8Array(prevOutput.buffer, prevOutput.byteOffset, prevOutput.byteLength),
   );
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, prevUpload);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
@@ -216,6 +251,7 @@ export type VHSGLParams = {
   rowShift: Int32Array;
   rowNoise: Float32Array;
   staticBar: Uint8Array;      // 1 per row in a noise bar
+  dropoutPacked: Float32Array;
   vJitter: number;
   chromaOffX: number;
   chromaOffY: number;
@@ -223,7 +259,6 @@ export type VHSGLParams = {
   saturation: number;
   brightness: number;
   ghosting: number;
-  dropoutProb: number;
   tapeNoise: number;
   frameIndex: number;
   prevOutput: Uint8ClampedArray | null;
@@ -249,7 +284,14 @@ export const renderVHSGL = (
   const sourceTex = ensureTexture(gl, "vhs:source", width, height);
   uploadSourceTexture(gl, sourceTex, source);
 
-  const rowStateTex = uploadRowState(gl, params.rowShift, params.rowNoise, params.staticBar, height);
+  const rowStateTex = uploadRowState(
+    gl,
+    params.rowShift,
+    params.rowNoise,
+    params.staticBar,
+    params.dropoutPacked,
+    height,
+  );
   const prevTex = uploadPrevOutputTexture(gl, params.prevOutput, width, height);
 
   // When blur is enabled we render VHS into a scratch texture and then
@@ -275,7 +317,6 @@ export const renderVHSGL = (
     gl.uniform1f(cache.vhs.uniforms.u_brightness, params.brightness);
     gl.uniform1f(cache.vhs.uniforms.u_ghosting, params.ghosting);
     gl.uniform1i(cache.vhs.uniforms.u_hasPrev, prevTex ? 1 : 0);
-    gl.uniform1f(cache.vhs.uniforms.u_dropoutProb, params.dropoutProb);
     gl.uniform1f(cache.vhs.uniforms.u_tapeNoise, params.tapeNoise);
     gl.uniform1f(cache.vhs.uniforms.u_frameIndex, params.frameIndex);
   }, vao);

--- a/src/filters/vhsNtsc.ts
+++ b/src/filters/vhsNtsc.ts
@@ -1,0 +1,201 @@
+import { ACTION, BOOL, ENUM, PALETTE, RANGE } from "constants/controlTypes";
+import { defineFilter } from "filters/types";
+import { nearest } from "palettes";
+import { applyPalettePassToCanvas, paletteIsIdentity } from "palettes/backend";
+import { logFilterBackend } from "utils";
+import { renderVHSNTSCGL } from "./vhsNtscGL";
+
+export const optionTypes = {
+  tapeSpeed: {
+    type: ENUM,
+    options: [
+      { name: "SP (best quality)", value: "SP" },
+      { name: "LP", value: "LP" },
+      { name: "EP / SLP (softest)", value: "EP" },
+      { name: "Composite only", value: "NONE" },
+    ],
+    default: "LP",
+    desc: "VHS recording speed; slower modes reduce luma/chroma bandwidth and increase color delay",
+  },
+  fieldMode: {
+    type: ENUM,
+    options: [
+      { name: "Interleaved", value: "INTERLEAVED" },
+      { name: "Both / progressive", value: "BOTH" },
+      { name: "Upper field", value: "UPPER" },
+      { name: "Lower field", value: "LOWER" },
+    ],
+    default: "INTERLEAVED",
+    desc: "How scanline fields drive carrier phase and source-line selection",
+  },
+  filterType: {
+    type: ENUM,
+    options: [
+      { name: "Butterworth (sharper)", value: "BUTTERWORTH" },
+      { name: "Constant K (blurrier)", value: "CONSTANT_K" },
+    ],
+    default: "BUTTERWORTH",
+    desc: "Shape of the luma and chroma bandwidth filters",
+  },
+  demodulation: {
+    type: ENUM,
+    options: [
+      { name: "Notch", value: "NOTCH" },
+      { name: "One-line comb", value: "ONE_LINE_COMB" },
+      { name: "Two-line comb", value: "TWO_LINE_COMB" },
+    ],
+    default: "NOTCH",
+    desc: "NTSC luma/chroma separation method; comb filters suppress dot crawl at the cost of vertical blending",
+  },
+  compositeSharpness: { type: RANGE, range: [0, 2], step: 0.05, default: 1, desc: "Pre-emphasis applied before composite modulation" },
+  compositeNoise: { type: RANGE, range: [0, 1], step: 0.01, default: 0.05, desc: "Noise injected into the modulated composite waveform" },
+  snow: { type: RANGE, range: [0, 0.1], step: 0.00025, default: 0.00025, desc: "Sparse RF transients and white speckles" },
+  snowAnisotropy: { type: RANGE, range: [0, 1], step: 0.01, default: 0.5, desc: "Clump snow into horizontal tape lines" },
+  headSwitching: { type: RANGE, range: [0, 160], step: 1, default: 72, desc: "Horizontal displacement in the bottom head-switching band" },
+  headSwitchingHeight: { type: RANGE, range: [0, 64], step: 1, default: 8, desc: "Height of the bottom head-switching band" },
+  trackingNoise: { type: RANGE, range: [0, 60], step: 1, default: 15, desc: "Wavy time-base error near the bottom of the image" },
+  trackingHeight: { type: RANGE, range: [0, 96], step: 1, default: 12, desc: "Height of the tracking disturbance region" },
+  edgeWave: { type: RANGE, range: [0, 8], step: 0.1, default: 0.5, desc: "Slow whole-frame VHS edge waviness" },
+  lumaSmear: { type: RANGE, range: [0, 1], step: 0.01, default: 0.5, desc: "Asymmetric horizontal luminance smear" },
+  ringing: { type: RANGE, range: [0, 1], step: 0.01, default: 0.15, desc: "Luma ringing from imperfect notch and tape filters" },
+  lumaNoise: { type: RANGE, range: [0, 1], step: 0.01, default: 0.01, desc: "Noise added after luma demodulation" },
+  chromaNoise: { type: RANGE, range: [0, 1], step: 0.01, default: 0.1, desc: "Low-frequency noise in the decoded color signal" },
+  chromaPhaseNoise: { type: RANGE, range: [0, 1], step: 0.001, default: 0.001, desc: "Random per-line hue flutter from chroma carrier timing error" },
+  chromaPhaseError: { type: RANGE, range: [-1, 1], step: 0.01, default: 0, desc: "Constant chroma phase error, expressed as a half-turn" },
+  chromaDelayH: { type: RANGE, range: [-12, 12], step: 0.5, default: 0, desc: "Additional horizontal chroma delay in pixels" },
+  chromaDelayV: { type: RANGE, range: [-4, 4], step: 1, default: 0, desc: "Additional vertical chroma delay in scanlines" },
+  chromaLoss: { type: RANGE, range: [0, 0.25], step: 0.000025, default: 0.000025, desc: "Probability that a scanline loses all color" },
+  chromaVertBlend: { type: BOOL, default: true, desc: "Blend each chroma scanline with the preceding line as VHS does" },
+  randomSeed: { type: RANGE, range: [0, 9999], step: 1, default: 0, desc: "Deterministic noise and defect seed" },
+  animSpeed: { type: RANGE, range: [1, 30], step: 1, default: 12, desc: "Preview animation frame rate" },
+  animate: {
+    type: ACTION,
+    label: "Play / Stop",
+    action: (actions: any, inputCanvas: any, _filterFunc: any, options: any) => {
+      if (actions.isAnimating()) {
+        actions.stopAnimLoop();
+      } else {
+        actions.startAnimLoop(inputCanvas, options.animSpeed || 12);
+      }
+    },
+  },
+  palette: { type: PALETTE, default: nearest },
+};
+
+export const defaults = {
+  tapeSpeed: optionTypes.tapeSpeed.default,
+  fieldMode: optionTypes.fieldMode.default,
+  filterType: optionTypes.filterType.default,
+  demodulation: optionTypes.demodulation.default,
+  compositeSharpness: optionTypes.compositeSharpness.default,
+  compositeNoise: optionTypes.compositeNoise.default,
+  snow: optionTypes.snow.default,
+  snowAnisotropy: optionTypes.snowAnisotropy.default,
+  headSwitching: optionTypes.headSwitching.default,
+  headSwitchingHeight: optionTypes.headSwitchingHeight.default,
+  trackingNoise: optionTypes.trackingNoise.default,
+  trackingHeight: optionTypes.trackingHeight.default,
+  edgeWave: optionTypes.edgeWave.default,
+  lumaSmear: optionTypes.lumaSmear.default,
+  ringing: optionTypes.ringing.default,
+  lumaNoise: optionTypes.lumaNoise.default,
+  chromaNoise: optionTypes.chromaNoise.default,
+  chromaPhaseNoise: optionTypes.chromaPhaseNoise.default,
+  chromaPhaseError: optionTypes.chromaPhaseError.default,
+  chromaDelayH: optionTypes.chromaDelayH.default,
+  chromaDelayV: optionTypes.chromaDelayV.default,
+  chromaLoss: optionTypes.chromaLoss.default,
+  chromaVertBlend: optionTypes.chromaVertBlend.default,
+  randomSeed: optionTypes.randomSeed.default,
+  animSpeed: optionTypes.animSpeed.default,
+  palette: { ...optionTypes.palette.default, options: { levels: 256 } },
+};
+
+const FIELD_MODE: Record<string, number> = {
+  INTERLEAVED: 0,
+  BOTH: 1,
+  UPPER: 2,
+  LOWER: 3,
+};
+
+const FILTER_TYPE: Record<string, number> = {
+  BUTTERWORTH: 0,
+  CONSTANT_K: 1,
+};
+
+const DEMODULATION: Record<string, number> = {
+  NOTCH: 0,
+  ONE_LINE_COMB: 1,
+  TWO_LINE_COMB: 2,
+};
+
+const TAPE_PROFILE: Record<string, { lumaRadius: number; chromaRadius: number; chromaDelay: number }> = {
+  NONE: { lumaRadius: 0, chromaRadius: 0, chromaDelay: 0 },
+  SP: { lumaRadius: 1, chromaRadius: 4, chromaDelay: 4 },
+  LP: { lumaRadius: 2, chromaRadius: 6, chromaDelay: 5 },
+  EP: { lumaRadius: 3, chromaRadius: 8, chromaDelay: 6 },
+};
+
+type VHSNTSCOptions = typeof defaults & { _frameIndex?: number };
+
+const vhsNtsc = (
+  input: HTMLCanvasElement | OffscreenCanvas,
+  options: VHSNTSCOptions = defaults,
+) => {
+  const width = input.width;
+  const height = input.height;
+  const tape = TAPE_PROFILE[options.tapeSpeed] ?? TAPE_PROFILE.LP;
+  const frame = Number(options._frameIndex ?? 0);
+
+  const rendered = renderVHSNTSCGL(input, width, height, {
+    frame,
+    seed: options.randomSeed,
+    fieldMode: FIELD_MODE[options.fieldMode] ?? FIELD_MODE.INTERLEAVED,
+    filterType: FILTER_TYPE[options.filterType] ?? FILTER_TYPE.BUTTERWORTH,
+    demodulation: DEMODULATION[options.demodulation] ?? DEMODULATION.NOTCH,
+    lumaRadius: tape.lumaRadius,
+    chromaRadius: tape.chromaRadius,
+    tapeChromaDelay: tape.chromaDelay,
+    compositeSharpness: options.compositeSharpness,
+    compositeNoise: options.compositeNoise,
+    snow: options.snow,
+    snowAnisotropy: options.snowAnisotropy,
+    headSwitching: options.headSwitching,
+    headSwitchingHeight: options.headSwitchingHeight,
+    trackingNoise: options.trackingNoise,
+    trackingHeight: options.trackingHeight,
+    edgeWave: options.edgeWave,
+    chromaDelayH: options.chromaDelayH,
+    chromaDelayV: options.chromaDelayV,
+    chromaVertBlend: options.chromaVertBlend,
+    chromaLoss: options.chromaLoss,
+    chromaPhaseNoise: options.chromaPhaseNoise,
+    chromaPhaseError: options.chromaPhaseError,
+    lumaSmear: options.lumaSmear,
+    ringing: options.ringing,
+    lumaNoise: options.lumaNoise,
+    chromaNoise: options.chromaNoise,
+  });
+  if (!rendered) return input;
+
+  const identity = paletteIsIdentity(options.palette);
+  const output = identity
+    ? rendered
+    : applyPalettePassToCanvas(rendered, width, height, options.palette);
+  logFilterBackend(
+    "VHS / NTSC",
+    "WebGL2",
+    `${options.tapeSpeed}+${options.demodulation}${identity ? "" : "+palettePass"}`,
+  );
+  return output ?? input;
+};
+
+export default defineFilter({
+  name: "VHS / NTSC",
+  func: vhsNtsc,
+  options: defaults,
+  optionTypes,
+  defaults,
+  temporal: true,
+  requiresGL: true,
+});

--- a/src/filters/vhsNtscGL.ts
+++ b/src/filters/vhsNtscGL.ts
@@ -1,0 +1,479 @@
+import {
+  drawPass,
+  ensureTexture,
+  getGLCtx,
+  getQuadVAO,
+  glAvailable,
+  linkProgram,
+  readoutToCanvas,
+  resizeGLCanvas,
+  uploadSourceTexture,
+  type Program,
+} from "gl";
+
+// Pass 1 follows the first half of the ntsc-rs pipeline: RGB -> YIQ,
+// bandwidth-limited chroma, carrier modulation, then disturbances applied to
+// the scalar composite waveform. The signal is packed into R as [-2, 2].
+const COMPOSITE_FS = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_source;
+uniform vec2 u_res;
+uniform float u_frame;
+uniform float u_seed;
+uniform int u_fieldMode;
+uniform float u_compositeSharpness;
+uniform float u_compositeNoise;
+uniform float u_snow;
+uniform float u_snowAnisotropy;
+uniform float u_headSwitching;
+uniform float u_headSwitchingHeight;
+uniform float u_trackingNoise;
+uniform float u_trackingHeight;
+
+const float PI = 3.14159265358979323846;
+
+float hash(vec2 p) {
+  p += vec2(u_seed * 0.1031, u_seed * 0.11369);
+  return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec3 rgbToYiq(vec3 c) {
+  return vec3(
+    dot(c, vec3(0.299, 0.587, 0.114)),
+    dot(c, vec3(0.5959, -0.2746, -0.3213)),
+    dot(c, vec3(0.2115, -0.5227, 0.3112))
+  );
+}
+
+vec4 sourceAt(float x, float y) {
+  vec2 cp = clamp(vec2(x, y), vec2(0.0), u_res - vec2(1.0));
+  return texture(u_source, vec2(cp.x + 0.5, u_res.y - 0.5 - cp.y) / u_res);
+}
+
+float fieldSourceY(float y) {
+  if (u_fieldMode == 2) {
+    return clamp(floor(y * 0.5) * 2.0, 0.0, u_res.y - 1.0);
+  }
+  if (u_fieldMode == 3) {
+    return clamp(floor(y * 0.5) * 2.0 + 1.0, 0.0, u_res.y - 1.0);
+  }
+  return y;
+}
+
+float smoothLineNoise(float y, float speed, float seed) {
+  seed += u_seed * 0.0073;
+  float a = sin(y * 0.071 + u_frame * speed + seed);
+  float b = sin(y * 0.019 - u_frame * speed * 0.37 + seed * 2.3);
+  float c = sin(y * 0.233 + u_frame * speed * 0.11 + seed * 4.7);
+  return a * 0.58 + b * 0.29 + c * 0.13;
+}
+
+void main() {
+  vec2 px = v_uv * u_res;
+  float x = floor(px.x);
+  float y = u_res.y - 1.0 - floor(px.y);
+  float sy = fieldSourceY(y);
+
+  float headHeight = max(u_headSwitchingHeight, 1.0);
+  float headT = clamp((y - (u_res.y - headHeight)) / headHeight, 0.0, 1.0);
+  float headShift = pow(headT, 1.5) * u_headSwitching
+    * (0.82 + hash(vec2(floor(u_frame * 0.5), y)) * 0.36);
+
+  float trackingHeight = max(u_trackingHeight, 1.0);
+  float trackingT = clamp((y - (u_res.y - trackingHeight)) / trackingHeight, 0.0, 1.0);
+  float trackingShift = smoothLineNoise(y, 0.31, 9.1)
+    * u_trackingNoise * trackingT * trackingT;
+
+  float warpedX = x + headShift + trackingShift;
+  vec4 center = sourceAt(warpedX, sy);
+  vec3 centerYiq = rgbToYiq(center.rgb);
+
+  vec2 chroma = vec2(0.0);
+  float chromaWeight = 0.0;
+  for (int k = -3; k <= 3; k++) {
+    float weight = 4.0 - abs(float(k));
+    chroma += rgbToYiq(sourceAt(warpedX + float(k), sy).rgb).yz * weight;
+    chromaWeight += weight;
+  }
+  chroma /= chromaWeight;
+
+  float neighborY = (
+    rgbToYiq(sourceAt(warpedX - 1.0, sy).rgb).x
+    + rgbToYiq(sourceAt(warpedX + 1.0, sy).rgb).x
+  ) * 0.5;
+  float luma = centerYiq.x + (centerYiq.x - neighborY) * u_compositeSharpness * 0.18;
+
+  float phaseLine = u_fieldMode == 1 ? y : floor(y * 0.5);
+  float framePhase = u_fieldMode == 0 ? floor(u_frame) : 0.0;
+  float linePhase = mod(phaseLine + framePhase, 2.0) * PI;
+  float carrierPhase = warpedX * (PI * 0.5) + linePhase;
+  float composite = luma + chroma.x * cos(carrierPhase) + chroma.y * sin(carrierPhase);
+
+  float broadNoise = smoothLineNoise(y + x * 0.025, 0.43, 17.0);
+  composite += broadNoise * u_compositeNoise * 0.12;
+  composite += (hash(vec2(x + u_frame * 31.0, y)) - 0.5) * u_compositeNoise * 0.08;
+
+  float lineSnow = hash(vec2(y, floor(u_frame * 0.75) + 29.0));
+  float pixelSnow = hash(vec2(floor(x * 0.25), y + u_frame * 13.0));
+  float snowGate = mix(pixelSnow, lineSnow, u_snowAnisotropy);
+  if (snowGate < u_snow * 0.12) {
+    float transient = hash(vec2(x * 1.73 + 7.0, y + u_frame * 43.0));
+    composite += (transient * 2.0 - 0.65) * 0.9;
+  }
+
+  float packedSignal = clamp(composite * 0.25 + 0.5, 0.0, 1.0);
+  fragColor = vec4(packedSignal, centerYiq.x, 0.0, center.a);
+}
+`;
+
+// Pass 2 performs NTSC demodulation. The notch path separates the carrier
+// horizontally; comb modes use phase-opposed neighboring scanlines, matching
+// the one-line/two-line structure in ntsc-rs.
+const DEMODULATE_FS = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_composite;
+uniform vec2 u_res;
+uniform float u_frame;
+uniform int u_fieldMode;
+uniform int u_demodulation;
+
+const float PI = 3.14159265358979323846;
+const float IQ_PACK = 0.72;
+
+vec4 packedAt(float x, float y) {
+  vec2 cp = clamp(vec2(x, y), vec2(0.0), u_res - vec2(1.0));
+  return texture(u_composite, vec2(cp.x + 0.5, u_res.y - 0.5 - cp.y) / u_res);
+}
+
+float signalAt(float x, float y) {
+  return (packedAt(x, y).r - 0.5) * 4.0;
+}
+
+float notchLuma(float x, float y) {
+  return signalAt(x, y) * 0.5
+    + (signalAt(x - 2.0, y) + signalAt(x + 2.0, y)) * 0.25;
+}
+
+float lumaAt(float x, float y) {
+  float current = signalAt(x, y);
+  float lineStep = u_fieldMode == 1 ? 1.0 : 2.0;
+  float prevY = y >= lineStep ? y - lineStep : y + lineStep;
+  float nextY = y + lineStep < u_res.y ? y + lineStep : y - lineStep;
+  if (u_demodulation == 1) {
+    return (current + signalAt(x, prevY)) * 0.5;
+  }
+  if (u_demodulation == 2) {
+    return current * 0.5
+      + signalAt(x, prevY) * 0.25
+      + signalAt(x, nextY) * 0.25;
+  }
+  return notchLuma(x, y);
+}
+
+float carrierPhase(float x, float y) {
+  float phaseLine = u_fieldMode == 1 ? y : floor(y * 0.5);
+  float framePhase = u_fieldMode == 0 ? floor(u_frame) : 0.0;
+  float linePhase = mod(phaseLine + framePhase, 2.0) * PI;
+  return x * (PI * 0.5) + linePhase;
+}
+
+void main() {
+  vec2 px = v_uv * u_res;
+  float x = floor(px.x);
+  float y = u_res.y - 1.0 - floor(px.y);
+  float luma = lumaAt(x, y);
+
+  vec2 chroma = vec2(0.0);
+  for (int k = -1; k <= 1; k++) {
+    float fk = float(k);
+    float weight = k == 0 ? 1.0 : 0.5;
+    float sx = x + fk;
+    float residual = signalAt(sx, y) - lumaAt(sx, y);
+    float phase = carrierPhase(sx, y);
+    chroma += vec2(cos(phase), sin(phase)) * residual * weight;
+  }
+
+  fragColor = vec4(
+    clamp(luma, 0.0, 1.0),
+    clamp(chroma.x * IQ_PACK + 0.5, 0.0, 1.0),
+    clamp(chroma.y * IQ_PACK + 0.5, 0.0, 1.0),
+    packedAt(x, y).a
+  );
+}
+`;
+
+// Pass 3 applies the helical-tape bandwidth profile and converts back to RGB.
+// SP/LP/EP become progressively wider gather kernels and larger chroma delay.
+const TAPE_FS = `#version 300 es
+precision highp float;
+in vec2 v_uv;
+out vec4 fragColor;
+
+uniform sampler2D u_yiq;
+uniform vec2 u_res;
+uniform float u_frame;
+uniform float u_seed;
+uniform int u_filterType;
+uniform int u_lumaRadius;
+uniform int u_chromaRadius;
+uniform float u_tapeChromaDelay;
+uniform float u_chromaDelayH;
+uniform float u_chromaDelayV;
+uniform bool u_chromaVertBlend;
+uniform float u_chromaLoss;
+uniform float u_chromaPhaseNoise;
+uniform float u_chromaPhaseError;
+uniform float u_lumaSmear;
+uniform float u_ringing;
+uniform float u_lumaNoise;
+uniform float u_chromaNoise;
+uniform float u_edgeWave;
+
+const float PI = 3.14159265358979323846;
+const float IQ_PACK = 0.72;
+
+float hash(vec2 p) {
+  p += vec2(u_seed * 0.1031, u_seed * 0.11369);
+  return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+vec4 packedAt(float x, float y) {
+  vec2 cp = clamp(vec2(x, y), vec2(0.0), u_res - vec2(1.0));
+  return texture(u_yiq, vec2(cp.x + 0.5, u_res.y - 0.5 - cp.y) / u_res);
+}
+
+vec3 yiqAt(float x, float y) {
+  vec3 p = packedAt(x, y).rgb;
+  return vec3(p.r, (p.g - 0.5) / IQ_PACK, (p.b - 0.5) / IQ_PACK);
+}
+
+vec3 yiqToRgb(vec3 c) {
+  return vec3(
+    c.x + 0.956 * c.y + 0.619 * c.z,
+    c.x - 0.272 * c.y - 0.647 * c.z,
+    c.x - 1.106 * c.y + 1.703 * c.z
+  );
+}
+
+float tapWeight(int k, int radius) {
+  if (radius == 0) return k == 0 ? 1.0 : 0.0;
+  float distance = abs(float(k));
+  if (distance > float(radius)) return 0.0;
+  if (u_filterType == 1) {
+    return exp(-distance / max(float(radius) * 0.52, 0.5));
+  }
+  float normalized = distance / (float(radius) + 1.0);
+  return 1.0 / (1.0 + pow(normalized * 2.1, 4.0));
+}
+
+float edgeShiftForLine(float y) {
+  float seedPhase = u_seed * 0.0073;
+  float a = sin(y * 0.071 + u_frame * 0.055 + 1.7 + seedPhase);
+  float b = sin(y * 0.019 - u_frame * 0.02035 + 3.91 + seedPhase * 2.3);
+  float c = sin(y * 0.233 + u_frame * 0.00605 + 7.99 + seedPhase * 4.7);
+  return (a * 0.58 + b * 0.29 + c * 0.13) * u_edgeWave;
+}
+
+void main() {
+  vec2 px = v_uv * u_res;
+  float x = floor(px.x);
+  float y = u_res.y - 1.0 - floor(px.y);
+
+  float luma = 0.0;
+  float lumaWeight = 0.0;
+  vec2 chroma = vec2(0.0);
+  float chromaWeight = 0.0;
+  float baseX = x + edgeShiftForLine(y);
+  float chromaX = baseX + u_tapeChromaDelay + u_chromaDelayH;
+  float chromaY = y + u_chromaDelayV;
+
+  for (int k = -8; k <= 8; k++) {
+    float lw = tapWeight(k, u_lumaRadius);
+    float cw = tapWeight(k, u_chromaRadius);
+    luma += yiqAt(baseX + float(k), y).x * lw;
+    chroma += yiqAt(chromaX + float(k), chromaY).yz * cw;
+    lumaWeight += lw;
+    chromaWeight += cw;
+  }
+  luma /= max(lumaWeight, 0.0001);
+  chroma /= max(chromaWeight, 0.0001);
+
+  if (u_chromaVertBlend) {
+    vec2 above = vec2(0.0);
+    float aboveWeight = 0.0;
+    for (int k = -8; k <= 8; k++) {
+      float cw = tapWeight(k, u_chromaRadius);
+      above += yiqAt(chromaX + float(k), chromaY - 1.0).yz * cw;
+      aboveWeight += cw;
+    }
+    chroma = mix(chroma, above / max(aboveWeight, 0.0001), 0.5);
+  }
+
+  float smear1 = yiqAt(baseX - 1.0, y).x;
+  float smear2 = yiqAt(baseX - 2.0, y).x;
+  luma = mix(luma, luma * 0.55 + smear1 * 0.30 + smear2 * 0.15, u_lumaSmear);
+
+  float leftY = yiqAt(baseX - 1.0, y).x;
+  float rightY = yiqAt(baseX + 1.0, y).x;
+  luma += (luma - (leftY + rightY) * 0.5) * u_ringing * 0.65;
+
+  if (hash(vec2(y, floor(u_frame) + 113.0)) < u_chromaLoss) {
+    chroma = vec2(0.0);
+  }
+
+  float phase = u_chromaPhaseError * PI * 2.0
+    + (hash(vec2(y * 0.37, floor(u_frame * 0.5) + 47.0)) - 0.5)
+      * 2.0 * u_chromaPhaseNoise * PI * 2.0;
+  float cp = cos(phase);
+  float sp = sin(phase);
+  chroma = mat2(cp, sp, -sp, cp) * chroma;
+
+  luma += (hash(vec2(x + u_frame * 17.0, y * 1.7)) - 0.5) * u_lumaNoise * 0.16;
+  float chromaGrain = hash(vec2(floor(x * 0.25) + u_frame * 5.0, y + 83.0)) - 0.5;
+  chroma += vec2(chromaGrain, -chromaGrain * 0.63) * u_chromaNoise * 0.18;
+
+  vec3 rgb = clamp(yiqToRgb(vec3(luma, chroma)), 0.0, 1.0);
+  fragColor = vec4(rgb, packedAt(x, y).a);
+}
+`;
+
+type Cache = {
+  composite: Program;
+  demodulate: Program;
+  tape: Program;
+};
+
+let _cache: Cache | null = null;
+
+const initCache = (gl: WebGL2RenderingContext): Cache => {
+  if (_cache) return _cache;
+  _cache = {
+    composite: linkProgram(gl, COMPOSITE_FS, [
+      "u_source", "u_res", "u_frame", "u_seed", "u_fieldMode", "u_compositeSharpness",
+      "u_compositeNoise", "u_snow", "u_snowAnisotropy", "u_headSwitching",
+      "u_headSwitchingHeight", "u_trackingNoise", "u_trackingHeight",
+    ] as const),
+    demodulate: linkProgram(gl, DEMODULATE_FS, [
+      "u_composite", "u_res", "u_frame", "u_fieldMode", "u_demodulation",
+    ] as const),
+    tape: linkProgram(gl, TAPE_FS, [
+      "u_yiq", "u_res", "u_frame", "u_seed", "u_filterType", "u_lumaRadius",
+      "u_chromaRadius", "u_tapeChromaDelay", "u_chromaDelayH", "u_chromaDelayV",
+      "u_chromaVertBlend", "u_chromaLoss", "u_chromaPhaseNoise",
+      "u_chromaPhaseError", "u_lumaSmear", "u_ringing", "u_lumaNoise",
+      "u_chromaNoise", "u_edgeWave",
+    ] as const),
+  };
+  return _cache;
+};
+
+export const vhsNtscGLAvailable = (): boolean => glAvailable();
+
+export type VHSNTSCGLParams = {
+  frame: number;
+  seed: number;
+  fieldMode: number;
+  filterType: number;
+  demodulation: number;
+  lumaRadius: number;
+  chromaRadius: number;
+  tapeChromaDelay: number;
+  compositeSharpness: number;
+  compositeNoise: number;
+  snow: number;
+  snowAnisotropy: number;
+  headSwitching: number;
+  headSwitchingHeight: number;
+  trackingNoise: number;
+  trackingHeight: number;
+  edgeWave: number;
+  chromaDelayH: number;
+  chromaDelayV: number;
+  chromaVertBlend: boolean;
+  chromaLoss: number;
+  chromaPhaseNoise: number;
+  chromaPhaseError: number;
+  lumaSmear: number;
+  ringing: number;
+  lumaNoise: number;
+  chromaNoise: number;
+};
+
+export const renderVHSNTSCGL = (
+  source: HTMLCanvasElement | OffscreenCanvas,
+  width: number,
+  height: number,
+  params: VHSNTSCGLParams,
+): HTMLCanvasElement | OffscreenCanvas | null => {
+  const ctx = getGLCtx();
+  if (!ctx) return null;
+  const { gl, canvas } = ctx;
+  const cache = initCache(gl);
+  const vao = getQuadVAO(gl);
+
+  resizeGLCanvas(canvas, width, height);
+  const sourceTex = ensureTexture(gl, "vhsNtsc:source", width, height);
+  const compositeTex = ensureTexture(gl, "vhsNtsc:composite", width, height);
+  const yiqTex = ensureTexture(gl, "vhsNtsc:yiq", width, height);
+  uploadSourceTexture(gl, sourceTex, source);
+
+  drawPass(gl, compositeTex, width, height, cache.composite, () => {
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, sourceTex.tex);
+    gl.uniform1i(cache.composite.uniforms.u_source, 0);
+    gl.uniform2f(cache.composite.uniforms.u_res, width, height);
+    gl.uniform1f(cache.composite.uniforms.u_frame, params.frame);
+    gl.uniform1f(cache.composite.uniforms.u_seed, params.seed);
+    gl.uniform1i(cache.composite.uniforms.u_fieldMode, params.fieldMode);
+    gl.uniform1f(cache.composite.uniforms.u_compositeSharpness, params.compositeSharpness);
+    gl.uniform1f(cache.composite.uniforms.u_compositeNoise, params.compositeNoise);
+    gl.uniform1f(cache.composite.uniforms.u_snow, params.snow);
+    gl.uniform1f(cache.composite.uniforms.u_snowAnisotropy, params.snowAnisotropy);
+    gl.uniform1f(cache.composite.uniforms.u_headSwitching, params.headSwitching);
+    gl.uniform1f(cache.composite.uniforms.u_headSwitchingHeight, params.headSwitchingHeight);
+    gl.uniform1f(cache.composite.uniforms.u_trackingNoise, params.trackingNoise);
+    gl.uniform1f(cache.composite.uniforms.u_trackingHeight, params.trackingHeight);
+  }, vao);
+
+  drawPass(gl, yiqTex, width, height, cache.demodulate, () => {
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, compositeTex.tex);
+    gl.uniform1i(cache.demodulate.uniforms.u_composite, 0);
+    gl.uniform2f(cache.demodulate.uniforms.u_res, width, height);
+    gl.uniform1f(cache.demodulate.uniforms.u_frame, params.frame);
+    gl.uniform1i(cache.demodulate.uniforms.u_fieldMode, params.fieldMode);
+    gl.uniform1i(cache.demodulate.uniforms.u_demodulation, params.demodulation);
+  }, vao);
+
+  drawPass(gl, null, width, height, cache.tape, () => {
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, yiqTex.tex);
+    gl.uniform1i(cache.tape.uniforms.u_yiq, 0);
+    gl.uniform2f(cache.tape.uniforms.u_res, width, height);
+    gl.uniform1f(cache.tape.uniforms.u_frame, params.frame);
+    gl.uniform1f(cache.tape.uniforms.u_seed, params.seed);
+    gl.uniform1i(cache.tape.uniforms.u_filterType, params.filterType);
+    gl.uniform1i(cache.tape.uniforms.u_lumaRadius, params.lumaRadius);
+    gl.uniform1i(cache.tape.uniforms.u_chromaRadius, params.chromaRadius);
+    gl.uniform1f(cache.tape.uniforms.u_tapeChromaDelay, params.tapeChromaDelay);
+    gl.uniform1f(cache.tape.uniforms.u_chromaDelayH, params.chromaDelayH);
+    gl.uniform1f(cache.tape.uniforms.u_chromaDelayV, params.chromaDelayV);
+    gl.uniform1i(cache.tape.uniforms.u_chromaVertBlend, params.chromaVertBlend ? 1 : 0);
+    gl.uniform1f(cache.tape.uniforms.u_chromaLoss, params.chromaLoss);
+    gl.uniform1f(cache.tape.uniforms.u_chromaPhaseNoise, params.chromaPhaseNoise);
+    gl.uniform1f(cache.tape.uniforms.u_chromaPhaseError, params.chromaPhaseError);
+    gl.uniform1f(cache.tape.uniforms.u_lumaSmear, params.lumaSmear);
+    gl.uniform1f(cache.tape.uniforms.u_ringing, params.ringing);
+    gl.uniform1f(cache.tape.uniforms.u_lumaNoise, params.lumaNoise);
+    gl.uniform1f(cache.tape.uniforms.u_chromaNoise, params.chromaNoise);
+    gl.uniform1f(cache.tape.uniforms.u_edgeWave, params.edgeWave);
+  }, vao);
+
+  return readoutToCanvas(canvas, width, height);
+};

--- a/test/filters/vhsNtsc.test.ts
+++ b/test/filters/vhsNtsc.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { filterIndex, filterList } from "filters";
+import vhs, {
+  buildTrackingRowShift,
+  defaults as vhsDefaults,
+  stochasticEventCount,
+} from "filters/vhs";
+import vhsNtsc, { defaults as vhsNtscDefaults } from "filters/vhsNtsc";
+
+describe("VHS emulation frame state", () => {
+  it("turns fractional expected event counts into deterministic occasional events", () => {
+    expect(stochasticEventCount(0.8, 0.79)).toBe(1);
+    expect(stochasticEventCount(0.8, 0.8)).toBe(0);
+    expect(stochasticEventCount(2.25, 0.24)).toBe(3);
+    expect(stochasticEventCount(2.25, 0.25)).toBe(2);
+  });
+
+  it("keeps tracking deterministic and changes adjacent frames smoothly", () => {
+    const frame0 = buildTrackingRowShift(240, 12, 0.8, 0);
+    const frame0Again = buildTrackingRowShift(240, 12, 0.8, 0);
+    const frame1 = buildTrackingRowShift(240, 12, 0.8, 1);
+    const frame8 = buildTrackingRowShift(240, 12, 0.8, 8);
+
+    expect(Array.from(frame0Again)).toEqual(Array.from(frame0));
+
+    const adjacentDelta = frame0.reduce(
+      (sum, value, index) => sum + Math.abs(value - frame1[index]),
+      0,
+    );
+    const profileDelta = frame0.reduce(
+      (sum, value, index) => sum + Math.abs(value - frame8[index]),
+      0,
+    );
+
+    expect(adjacentDelta).toBeLessThan(profileDelta);
+  });
+
+  it("ships a tape-like chroma bandwidth default", () => {
+    expect(vhsDefaults.chromaBandwidth).toBeGreaterThan(0);
+    expect(vhs.temporal).toBe(true);
+  });
+});
+
+describe("VHS / NTSC filter", () => {
+  it("is a registered GL-only signal-model filter", () => {
+    expect(vhsNtsc.requiresGL).toBe(true);
+    expect(vhsNtsc.temporal).toBe(true);
+    expect(filterIndex["VHS / NTSC"]).toBe(vhsNtsc);
+    expect(filterList.some((entry) => entry.displayName === "VHS / NTSC")).toBe(true);
+  });
+
+  it("defaults to LP tape and an NTSC notch decoder", () => {
+    expect(vhsNtscDefaults.tapeSpeed).toBe("LP");
+    expect(vhsNtscDefaults.demodulation).toBe("NOTCH");
+    expect(vhsNtscDefaults.fieldMode).toBe("INTERLEAVED");
+    expect(vhsNtscDefaults.chromaVertBlend).toBe(true);
+    expect(vhsNtscDefaults.snow).toBe(0.00025);
+    expect(vhsNtscDefaults.chromaPhaseNoise).toBe(0.001);
+    expect(vhsNtscDefaults.chromaLoss).toBe(0.000025);
+  });
+
+  it("exposes the main transmission and tape controls", () => {
+    expect(vhsNtsc.optionTypes).toMatchObject({
+      tapeSpeed: { type: "ENUM" },
+      demodulation: { type: "ENUM" },
+      compositeNoise: { type: "RANGE" },
+      headSwitching: { type: "RANGE" },
+      trackingNoise: { type: "RANGE" },
+      chromaPhaseNoise: { type: "RANGE" },
+      chromaLoss: { type: "RANGE" },
+      chromaVertBlend: { type: "BOOL" },
+    });
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,17 @@
+// Node 25 exposes a global `localStorage` property whose value is undefined
+// unless --localstorage-file is supplied. That prevents Vitest/jsdom from
+// installing its functional Storage implementation on globalThis.
+const entries = new Map<string, string>();
+const localStorageMock: Storage = {
+  get length() { return entries.size; },
+  clear() { entries.clear(); },
+  getItem(key) { return entries.get(key) ?? null; },
+  key(index) { return [...entries.keys()][index] ?? null; },
+  removeItem(key) { entries.delete(key); },
+  setItem(key, value) { entries.set(String(key), String(value)); },
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: localStorageMock,
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -62,7 +62,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: "jsdom",
-    setupFiles: ["vitest-canvas-mock"],
+    setupFiles: ["vitest-canvas-mock", "./test/setup.ts"],
     disableConsoleIntercept: true,
     exclude: [...configDefaults.exclude, "test/e2e/**"],
     coverage: {


### PR DESCRIPTION
Summary:
- make the existing VHS shader more tape-like and deterministic across CPU/GL paths
- add a three-pass WebGL2 VHS/NTSC signal-model filter derived from ntsc-rs
- fix Camera Shake GLSL compilation and Node 25 localStorage test setup

Validation:
- npm run lint
- npm run typecheck
- npm run test (956 passed, 129 skipped)
- npm run build
- npm run test:e2e:gl (382 passed, 150 skipped)
- upstream ntsc-rs core tests (66 passed)
- 640x480 upstream delta: RGB MAE 21.86, luma MAE 10.34, PSNR 17.85 dB