### PR TITLE
Harden filter package boundary for 0.1.1

### DIFF
--- a/.github/workflows/publish-filters.yml
+++ b/.github/workflows/publish-filters.yml
@@ -38,7 +38,7 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run test
-      - run: npm run build:lib
+      - run: npm run build:packed-app
       - name: Publish to GitHub Packages
         working-directory: packages/ditherer-filters
         run: npm publish --access public

--- a/docs/plan/053-package-boundary-hardening.md
+++ b/docs/plan/053-package-boundary-hardening.md
@@ -1,0 +1,78 @@
+# 053 — Package Boundary Hardening
+
+## Goal
+
+Make the Ditherer application prove that it can consume the exact packed
+`@gyng/ditherer-filters` artifact that other projects install. Keep the fast
+source-based development loop, but add a release gate that cannot accidentally
+fall back to repository source aliases.
+
+This milestone prepares `@gyng/ditherer-filters@0.1.1` and closes the remaining
+monorepo-specific gaps found after the initial `0.1.0` GitHub Packages release.
+
+## Workspace contract
+
+- Declare `packages/ditherer-filters` as an npm workspace.
+- Add `@gyng/ditherer-filters` as an explicit application dependency whose
+  version matches the workspace package.
+- Keep the package React-independent and independently packable.
+- Ensure `npm ci` creates the workspace link deterministically from the lockfile.
+
+The ordinary Vite development configuration may continue resolving the public
+package entries to package source so a fresh checkout does not require a library
+build before `npm run dev`. The packed-artifact gate must override those entries
+with files installed from the generated tarball.
+
+## Module-resolution cleanup
+
+Production application code imports the engine only through
+`@gyng/ditherer-filters` public entries. Legacy `filters`, `gl`, `palettes`,
+`wasm`, `workers`, package `constants`, and root package `utils` aliases are
+test-only implementation access and must not participate in the application
+build resolver.
+
+- Remove unused legacy engine paths from the application TypeScript config.
+- Move implementation aliases still needed by focused engine tests into the
+  Vitest-only alias configuration.
+- Retain application-owned `utils/*` and other UI aliases.
+
+## Packed application gate
+
+Extend the packed-package fixture so one command:
+
+1. builds and packs the library;
+2. installs the tarball into the isolated consumer fixture;
+3. builds the real Ditherer application with its four public package entries
+   resolved from that installed artifact;
+4. writes the build outside the normal application output directory; and
+5. verifies the output contains the package's module-worker and WASM assets.
+
+The special Vite config must fail early if the packed dependency has not been
+prepared. It must not resolve any `@gyng/ditherer-filters` import from
+`packages/ditherer-filters/src`.
+
+## Release documentation
+
+- Add a package changelog beginning with `0.1.0` and the boundary-hardening
+  `0.1.1` release.
+- Document the exact version bump, verification, tag, and GitHub Packages
+  workflow procedure.
+- Include the changelog in the published artifact.
+
+## Release gates
+
+- clean `npm ci` workspace/link contract, as represented by `package-lock.json`;
+- `npm run lint` and `npm run typecheck`;
+- targeted package-boundary and artifact-validation tests;
+- `npm run test`;
+- packed-library consumer test;
+- packed Ditherer production build;
+- ordinary application production build;
+- `npm run test:gl` after the package rebuild;
+- publish only from a green merge commit tagged `filters-v0.1.1`.
+
+## Later work
+
+Per-filter subpath exports and lazy catalog loading remain a `0.2.0` concern.
+They change the public API and bundle topology and are intentionally separate
+from this release-hardening patch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "ditherer",
       "version": "0.1.0",
       "license": "MIT",
+      "workspaces": [
+        "packages/ditherer-filters"
+      ],
       "dependencies": {
+        "@gyng/ditherer-filters": "0.1.1",
         "@radix-ui/react-popover": "^1.1.15",
         "cmdk": "^1.1.1",
         "fflate": "^0.8.2",
@@ -484,6 +488,10 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@gyng/ditherer-filters": {
+      "resolved": "packages/ditherer-filters",
+      "link": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1418,7 +1426,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1428,7 +1436,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2071,7 +2079,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4300,6 +4308,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ditherer-filters": {
+      "name": "@gyng/ditherer-filters",
+      "version": "0.1.1",
+      "license": "MIT",
+      "devDependencies": {
+        "fflate": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "name": "ditherer",
   "version": "0.1.0",
   "type": "module",
+  "workspaces": [
+    "packages/ditherer-filters"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "build:lib": "npm --prefix packages/ditherer-filters run build",
-    "test:lib": "npm run build:lib && tsc --noEmit -p test/library-consumer/tsconfig.json && node test/library-consumer/prepare-packed-library.mjs && node test/library-consumer/fixture/exports-smoke.mjs && playwright test test/e2e/library-package.spec.ts --config=test/library-consumer/playwright.config.ts --project=chromium",
+    "prepare:packed-lib": "node test/library-consumer/prepare-packed-library.mjs",
+    "build:packed-app": "npm run build:lib && npm run prepare:packed-lib && vite build --config test/library-consumer/vite.packed-app.config.mjs && node scripts/packed-app-artifacts.mjs /tmp/ditherer-packed-app-build",
+    "test:lib": "npm run build:lib && tsc --noEmit -p test/library-consumer/tsconfig.json && npm run prepare:packed-lib && node test/library-consumer/fixture/exports-smoke.mjs && playwright test test/e2e/library-package.spec.ts --config=test/library-consumer/playwright.config.ts --project=chromium",
     "preview": "vite preview",
     "lint": "eslint src test scripts packages/ditherer-filters/src packages/ditherer-filters/vite.config.ts vite.config.js",
     "typecheck": "tsc --noEmit",
@@ -21,7 +26,7 @@
     "test:e2e:gl": "env -u NO_COLOR -u FORCE_COLOR playwright test test/e2e/gl.smoke.spec.ts",
     "test:e2e:webmcp": "env -u NO_COLOR -u FORCE_COLOR PLAYWRIGHT_WEBMCP=1 playwright test test/e2e/webmcp.spec.ts --project=chromium",
     "test:gl": "npm run test:e2e:gl",
-    "check": "npm run lint && npm run typecheck && npm run test:coverage && npm run build:lib && npm run build",
+    "check": "npm run lint && npm run typecheck && npm run test:coverage && npm run build:packed-app && npm run build",
     "test:watch": "vitest",
     "bench": "vitest bench test/perf",
     "bench:compare": "node test/perf/compareBench.mjs",
@@ -30,6 +35,7 @@
     "report:presets": "npx vite-node scripts/report-preset-similarities.ts"
   },
   "dependencies": {
+    "@gyng/ditherer-filters": "0.1.1",
     "@radix-ui/react-popover": "^1.1.15",
     "cmdk": "^1.1.1",
     "fflate": "^0.8.2",

--- a/packages/ditherer-filters/CHANGELOG.md
+++ b/packages/ditherer-filters/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to `@gyng/ditherer-filters` are documented here. The
+package follows semantic versioning.
+
+## [0.1.1] - 2026-07-16
+
+### Changed
+
+- Declared the filter package as an npm workspace and an explicit Ditherer
+  application dependency.
+- Added a release gate that builds the real Ditherer app against the packed
+  tarball and verifies its module worker and RGB-to-Lab WASM payload.
+- Restricted legacy engine implementation aliases to Vitest so production
+  application builds consume only the public package entries.
+- Added a documented, reproducible GitHub Packages release procedure.
+
+## [0.1.0] - 2026-07-16
+
+### Added
+
+- Initial React-independent filter catalog and session runtime.
+- Canvas2D, WebGL2, worker, temporal-state, palette, and optional WASM support.
+- Root, client, worker, and WASM-bindings public entries with generated types.
+- Packed consumer, browser, application, and complete shader-registry gates.

--- a/packages/ditherer-filters/README.md
+++ b/packages/ditherer-filters/README.md
@@ -57,6 +57,5 @@ The first release target is a modern browser bundler. WebGL-only filters report
 `requiresGL` in their definition; `glAvailable()` can be used for capability
 checks. `wasmReady` resolves after the optional acceleration module initializes.
 
-Maintainers can publish the version in `package.json` by manually running the
-`Publish filter package` GitHub Actions workflow with that exact version, or by
-pushing a matching tag such as `filters-v0.1.0`.
+See [CHANGELOG.md](./CHANGELOG.md) for release notes and [RELEASING.md](./RELEASING.md)
+for the verified GitHub Packages release procedure.

--- a/packages/ditherer-filters/RELEASING.md
+++ b/packages/ditherer-filters/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing `@gyng/ditherer-filters`
+
+Releases are published to GitHub Packages from a merged, green `master`
+commit. Do not publish from a developer machine.
+
+## Prepare
+
+1. Update `version` in `packages/ditherer-filters/package.json`.
+2. Update the root application's exact `@gyng/ditherer-filters` dependency to
+   the same version.
+3. Add the release entry to `CHANGELOG.md`.
+4. Run `npm install --package-lock-only --ignore-scripts --legacy-peer-deps`
+   to update the workspace lock entry.
+
+## Verify
+
+Run the release gates from the repository root:
+
+```sh
+npm run check
+npm run test:lib
+npm run test:gl
+```
+
+`npm run build:packed-app` is included in `npm run check`. It builds the
+library, packs and installs its tarball in an isolated fixture, builds the real
+Ditherer application from those installed public entries, and verifies the
+filter worker and RGB-to-Lab WASM payload survived bundling.
+
+Open a pull request and wait for both the main CI and WebGL shader gate to pass.
+
+## Publish
+
+After merging, tag the exact merge commit with the package version:
+
+```sh
+git fetch origin master
+git tag -a filters-v0.1.1 origin/master -m "Release @gyng/ditherer-filters 0.1.1"
+git push origin filters-v0.1.1
+```
+
+The `Publish filter package` workflow validates that the tag and manifest
+versions match, repeats the package and packed-application gates, and publishes
+with the repository `GITHUB_TOKEN`. Confirm the workflow log ends with the
+expected `+ @gyng/ditherer-filters@<version>` line.
+
+The same workflow may be run manually with an exact version input when a tag
+event must be recovered. It will refuse a version that differs from the
+manifest.

--- a/packages/ditherer-filters/package.json
+++ b/packages/ditherer-filters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gyng/ditherer-filters",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ditherer's browser-native Canvas2D, WebGL2, and WASM image filter engine",
   "type": "module",
   "license": "MIT",
@@ -22,6 +22,8 @@
     "dist",
     "types",
     "README.md",
+    "CHANGELOG.md",
+    "RELEASING.md",
     "LICENSE"
   ],
   "exports": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,8 @@ const launchArgs = [
     ? ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport"]
     : []),
 ];
+const serverPort = Number(process.env.PLAYWRIGHT_PORT ?? 4173);
+const serverUrl = `http://127.0.0.1:${serverPort}`;
 
 export default defineConfig({
   testDir: "./test/e2e",
@@ -18,7 +20,7 @@ export default defineConfig({
     timeout: 10_000,
   },
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: serverUrl,
     headless: true,
     launchOptions: {
       executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
@@ -26,8 +28,8 @@ export default defineConfig({
     },
   },
   webServer: {
-    command: "env -u NO_COLOR -u FORCE_COLOR npm run dev -- --host 127.0.0.1 --port 4173",
-    url: "http://127.0.0.1:4173/wasm-smoke.html",
+    command: `env -u NO_COLOR -u FORCE_COLOR npm run dev -- --host 127.0.0.1 --port ${serverPort} --strictPort`,
+    url: `${serverUrl}/wasm-smoke.html`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/scripts/packed-app-artifacts.mjs
+++ b/scripts/packed-app-artifacts.mjs
@@ -1,0 +1,58 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const workerModulePattern = /(^|\/)filterWorker-[^/]+\.js$/;
+const inlineWasmMarker = "data:application/wasm;base64,";
+
+export const summarizePackedAppArtifacts = (files) => ({
+  hasHtmlEntry: files.has("index.html"),
+  hasWorkerModule: [...files.keys()].some((name) => workerModulePattern.test(name)),
+  hasWasmPayload: [...files.entries()].some(([name, contents]) =>
+    name.includes("rgba2laba")
+    && (
+      name.endsWith(".wasm")
+      || (name.endsWith(".js") && contents.includes(inlineWasmMarker))
+    )),
+});
+
+export const assertPackedAppArtifacts = (files) => {
+  const summary = summarizePackedAppArtifacts(files);
+  const missing = [];
+  if (!summary.hasHtmlEntry) missing.push("HTML entry");
+  if (!summary.hasWorkerModule) missing.push("filter worker module");
+  if (!summary.hasWasmPayload) missing.push("WASM payload");
+  if (missing.length > 0) {
+    throw new Error(`packed Ditherer build is missing ${missing.join(", ")}`);
+  }
+  return summary;
+};
+
+const readBuildFiles = async (root, directory = root, files = new Map()) => {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await readBuildFiles(root, absolutePath, files);
+      continue;
+    }
+    const relativePath = path.relative(root, absolutePath).replaceAll(path.sep, "/");
+    const contents = entry.name.endsWith(".js") || entry.name.endsWith(".html")
+      ? await readFile(absolutePath, "utf8")
+      : "";
+    files.set(relativePath, contents);
+  }
+  return files;
+};
+
+const isCommand = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCommand) {
+  const buildDirectory = path.resolve(process.argv[2] ?? "/tmp/ditherer-packed-app-build");
+  const files = await readBuildFiles(buildDirectory);
+  const summary = assertPackedAppArtifacts(files);
+  console.log(
+    `Packed Ditherer artifacts verified: ${files.size} files, `
+    + `worker=${summary.hasWorkerModule}, wasm=${summary.hasWasmPayload}`,
+  );
+}

--- a/src/components/SaveAs/hooks/useSaveAsRenderSync.ts
+++ b/src/components/SaveAs/hooks/useSaveAsRenderSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, type RefObject } from "react";
+import { useCallback, useRef, type RefObject } from "react";
 import type { FilterState } from "context/filterContextValue";
 import type { SourceVideoWithObjectUrl, VideoFrameCallbackVideo, VideoFrameMetadata } from "../helpers";
 
@@ -31,6 +31,9 @@ export const useSaveAsRenderSync = ({
   mult,
   gifFps,
 }: UseSaveAsRenderSyncOptions) => {
+  const targetSizeRef = useRef({ canvasWidth, canvasHeight, mult });
+  targetSizeRef.current = { canvasWidth, canvasHeight, mult };
+
   const getScaledCanvas = useCallback((): HTMLCanvasElement | null => {
     const source = outputCanvasRef.current;
     if (!source) return null;
@@ -39,8 +42,8 @@ export const useSaveAsRenderSync = ({
       scaled = document.createElement("canvas");
       scaledCanvasRef.current = scaled;
     }
-    const targetWidth = canvasWidth * mult;
-    const targetHeight = canvasHeight * mult;
+    const targetWidth = targetSizeRef.current.canvasWidth * targetSizeRef.current.mult;
+    const targetHeight = targetSizeRef.current.canvasHeight * targetSizeRef.current.mult;
     if (scaled.width !== targetWidth) scaled.width = targetWidth;
     if (scaled.height !== targetHeight) scaled.height = targetHeight;
     const ctx = scaled.getContext("2d");
@@ -49,7 +52,7 @@ export const useSaveAsRenderSync = ({
     ctx.clearRect(0, 0, scaled.width, scaled.height);
     ctx.drawImage(source, 0, 0, scaled.width, scaled.height);
     return scaled;
-  }, [outputCanvasRef, scaledCanvasRef, canvasWidth, canvasHeight, mult]);
+  }, [outputCanvasRef, scaledCanvasRef]);
 
   const estimateVideoFps = useCallback((vid: HTMLVideoElement, fallback: number) => {
     const duration = vid.duration || 0;

--- a/test/components/SaveAs/useSaveAsRenderSync.test.tsx
+++ b/test/components/SaveAs/useSaveAsRenderSync.test.tsx
@@ -115,9 +115,10 @@ describe("useSaveAsRenderSync", () => {
   });
 
   it("uses the advertised output size while the mounted canvas is still stale", () => {
+    const retainedGetScaledCanvas = latest.getScaledCanvas;
     render(2, 10, 10, 7);
 
-    const scaled = latest.getScaledCanvas()!;
+    const scaled = retainedGetScaledCanvas()!;
     expect(source.width).toBe(8);
     expect(source.height).toBe(6);
     expect(scaled.width).toBe(20);

--- a/test/library-consumer/vite.packed-app.config.mjs
+++ b/test/library-consumer/vite.packed-app.config.mjs
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import baseConfig from "../../vite.config.js";
+
+const repositoryRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const installedPackageRoot = path.join(
+  repositoryRoot,
+  "test/library-consumer/fixture/node_modules/@gyng/ditherer-filters",
+);
+const packageManifestPath = path.join(installedPackageRoot, "package.json");
+
+if (!existsSync(packageManifestPath)) {
+  throw new Error(
+    "Packed filter package is not installed; run test/library-consumer/prepare-packed-library.mjs first",
+  );
+}
+
+const packageManifest = JSON.parse(readFileSync(packageManifestPath, "utf8"));
+if (packageManifest.name !== "@gyng/ditherer-filters") {
+  throw new Error(`Unexpected packed dependency: ${packageManifest.name ?? "unknown"}`);
+}
+
+const packageEntry = (relativePath) => {
+  const entry = path.join(installedPackageRoot, relativePath);
+  if (!existsSync(entry)) throw new Error(`Packed dependency is missing ${relativePath}`);
+  return entry;
+};
+
+const packedPackageAliases = [
+  { find: "@gyng/ditherer-filters/worker", replacement: packageEntry("dist/worker.js") },
+  { find: "@gyng/ditherer-filters/client", replacement: packageEntry("dist/client.js") },
+  { find: "@gyng/ditherer-filters/wasm-bindings", replacement: packageEntry("dist/wasm-bindings.js") },
+  { find: "@gyng/ditherer-filters", replacement: packageEntry("dist/index.js") },
+];
+const applicationAliases = (baseConfig.resolve?.alias ?? []).filter(({ find }) =>
+  typeof find !== "string" || !find.startsWith("@gyng/ditherer-filters"));
+
+export default defineConfig({
+  ...baseConfig,
+  resolve: {
+    ...baseConfig.resolve,
+    alias: [...packedPackageAliases, ...applicationAliases],
+  },
+  build: {
+    ...baseConfig.build,
+    outDir: "/tmp/ditherer-packed-app-build",
+    emptyOutDir: true,
+    manifest: true,
+  },
+});

--- a/test/packedAppArtifacts.test.ts
+++ b/test/packedAppArtifacts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertPackedAppArtifacts,
+  summarizePackedAppArtifacts,
+} from "../scripts/packed-app-artifacts.mjs";
+
+describe("packed application artifact validation", () => {
+  it("accepts a Ditherer build with the packaged worker and inline WASM payload", () => {
+    const files = new Map([
+      ["assets/rgba2laba-abc.js", "const wasm = 'data:application/wasm;base64,AGFzbQ=='"],
+      ["assets/filterWorker-def.js", "self.onmessage = () => {}"],
+      ["index.html", "<script type=module src=/assets/rgba2laba-abc.js></script>"],
+    ]);
+
+    expect(summarizePackedAppArtifacts(files)).toEqual({
+      hasHtmlEntry: true,
+      hasWorkerModule: true,
+      hasWasmPayload: true,
+    });
+    expect(() => assertPackedAppArtifacts(files)).not.toThrow();
+  });
+
+  it("accepts an emitted WASM file and rejects missing package runtime assets", () => {
+    const emittedWasm = new Map([
+      ["index.html", ""],
+      ["assets/filterWorker-def.js", ""],
+      ["assets/rgba2laba-abc.wasm", ""],
+    ]);
+    const missingRuntimeAssets = new Map([
+      ["index.html", ""],
+      ["assets/index-abc.js", "console.log('app')"],
+    ]);
+
+    expect(() => assertPackedAppArtifacts(emittedWasm)).not.toThrow();
+    expect(() => assertPackedAppArtifacts(missingRuntimeAssets)).toThrow(
+      "packed Ditherer build is missing filter worker module, WASM payload",
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,22 +23,12 @@
       "@src/*": ["./*"],
       "actions/*": ["actions/*"],
       "components/*": ["components/*"],
-      "constants/*": ["../packages/ditherer-filters/src/constants/*"],
       "containers/*": ["containers/*"],
       "context/*": ["context/*"],
-      "filters": ["../packages/ditherer-filters/src/filters/index.ts"],
-      "filters/*": ["../packages/ditherer-filters/src/filters/*"],
-      "gl": ["../packages/ditherer-filters/src/gl/index.ts"],
-      "gl/*": ["../packages/ditherer-filters/src/gl/*"],
-      "palettes": ["../packages/ditherer-filters/src/palettes/index.ts"],
-      "palettes/*": ["../packages/ditherer-filters/src/palettes/*"],
       "reducers/*": ["reducers/*"],
       "styles/*": ["styles/*"],
-      "utils": ["../packages/ditherer-filters/src/utils/index.ts"],
       "types/*": ["types/*"],
-      "utils/*": ["utils/*"],
-      "wasm/*": ["../packages/ditherer-filters/src/wasm/*"],
-      "workers/*": ["../packages/ditherer-filters/src/workers/*"]
+      "utils/*": ["utils/*"]
     }
   },
   "include": ["src", "packages/ditherer-filters/src"]

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,17 @@ import { configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
+const filterPackageSource = path.resolve(__dirname, "packages/ditherer-filters/src");
+const legacyEngineTestAliases = [
+  { find: "constants", replacement: path.join(filterPackageSource, "constants") },
+  { find: "filters", replacement: path.join(filterPackageSource, "filters") },
+  { find: "gl", replacement: path.join(filterPackageSource, "gl") },
+  { find: "palettes", replacement: path.join(filterPackageSource, "palettes") },
+  { find: /^utils$/, replacement: path.join(filterPackageSource, "utils/index.ts") },
+  { find: "workers", replacement: path.join(filterPackageSource, "workers") },
+  { find: "wasm", replacement: path.join(filterPackageSource, "wasm") },
+];
+
 export default defineConfig({
   plugins: [react({ include: /\.(jsx|tsx)$/ })],
   resolve: {
@@ -13,17 +24,10 @@ export default defineConfig({
       { find: "@gyng/ditherer-filters", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/index.ts") },
       { find: "@src", replacement: path.resolve(__dirname, "src") },
       { find: "components", replacement: path.resolve(__dirname, "src/components") },
-      { find: "constants", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/constants") },
       { find: "context", replacement: path.resolve(__dirname, "src/context") },
-      { find: "filters", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/filters") },
-      { find: "gl", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/gl") },
-      { find: "palettes", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/palettes") },
       { find: "reducers", replacement: path.resolve(__dirname, "src/reducers") },
       { find: "styles", replacement: path.resolve(__dirname, "src/styles") },
-      { find: /^utils$/, replacement: path.resolve(__dirname, "packages/ditherer-filters/src/utils/index.ts") },
       { find: "utils", replacement: path.resolve(__dirname, "src/utils") },
-      { find: "workers", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/workers") },
-      { find: "wasm", replacement: path.resolve(__dirname, "packages/ditherer-filters/src/wasm") },
     ],
   },
   build: {
@@ -65,6 +69,7 @@ export default defineConfig({
   },
   base: "./",
   test: {
+    alias: legacyEngineTestAliases,
     globals: false,
     environment: "jsdom",
     setupFiles: ["vitest-canvas-mock", "./test/setup.ts"],


### PR DESCRIPTION
## What changed

- declare `packages/ditherer-filters` as an npm workspace and exact application dependency
- move legacy engine aliases behind Vitest-only resolution
- build the real Ditherer app from an isolated install of the packed tarball
- verify the packaged worker and RGB-to-Lab WASM payload in release output
- add changelog and repeatable GitHub Packages release documentation
- prepare `@gyng/ditherer-filters@0.1.1`

## Why

The initial extraction proved the standalone package, but ordinary Ditherer builds still used source aliases. This adds a release gate that consumes the exact artifact other projects install, preventing package-only worker, WASM, export, or declaration regressions.

## Validation

- clean `npm ci --legacy-peer-deps --ignore-scripts` and workspace-link verification
- `npm run check`
- `npm run test:lib`
- `npm run test:gl`
- 1,369 unit tests passed
- installed-tarball browser consumer passed
- 830 GL paths, 678 shader compiles, 339 links, and 3,112 draws passed