### PR TITLE
Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/publish-filters.yml
+++ b/.github/workflows/publish-filters.yml
@@ -23,8 +23,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## What changed

- update `actions/checkout` from v4 to the current v7 major
- update `actions/setup-node` from v4 to the current v7 major
- apply the upgrade consistently to CI, deployment, and filter publication

## Why

GitHub now forces the v4 actions from their deprecated Node 20 runtime onto Node 24 and annotates every release. The official latest releases for both actions are v7, which targets the supported runtime directly.

## Validation

- official release APIs report `v7.0.0` for both actions
- workflow YAML changes only action runtime versions; Node project version and job commands are unchanged
- PR CI will verify clean checkout, setup, caching, tests, builds, and WebGL execution using the upgraded actions
